### PR TITLE
Fix library names and correct installation commands

### DIFF
--- a/documentation/docs/_build/installation_guide.html
+++ b/documentation/docs/_build/installation_guide.html
@@ -155,11 +155,11 @@
 <div class="highlight-bash notranslate"><div class="highlight"><pre><span></span>R<span class="w"> </span>--version
 </pre></div>
 </div>
-<p>3. Install MxM package (this part may take a while), and the daggity package. MxM package is necessary for
-AFS while daggity is only used in CRV to find the adjustment sets.
+<p>3. Install MXM package (this part may take a while), and the dagitty package. MXM package is necessary for
+AFS while dagitty is only used in CRV to find the adjustment sets.
 Note: Depending on the OS you may need to install CMake and GSL (GNU Scientific Library)</p>
-<div class="highlight-bash notranslate"><div class="highlight"><pre><span></span>Rscipt<span class="w"> </span>--vanilla<span class="w"> </span><span class="s2">&quot;install.packages(&quot;</span>MXM<span class="s2">&quot;, repos = &quot;</span>http://cran.us.r-project.org<span class="s2">&quot;)&quot;</span>
-Rscipt<span class="w"> </span>--vanilla<span class="w"> </span><span class="s2">&quot;install.packages(&quot;</span>daggity<span class="s2">&quot;, repos = &quot;</span>http://cran.us.r-project.org<span class="s2">&quot;)&quot;</span>
+<div class="highlight-bash notranslate"><div class="highlight"><pre><span></span>Rscript --vanilla -e "install.packages('MXM', repos = 'https://cran.r-project.org')"
+Rscript --vanilla -e "install.packages('dagitty', repos = 'https://cran.r-project.org')"
 </pre></div>
 </div>
 </section>


### PR DESCRIPTION
- Corrected library names: 'MxM' changed to 'MXM' and 'daggity' changed to 'dagitty' to match the proper CRAN package names.
- Fixed the use of the -e flag in Rscript: Ensures inline execution of the R command without opening an interactive session.
- Corrected quotation marks in the install.packages() function: Single quotes are required around package names in R commands, replacing incorrect double quotes inside the function.

These changes ensure proper package installation and consistency with R best practices.